### PR TITLE
return ErrCorruptedSegment to handle corrupted segment files

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,3 @@ module github.com/joncrlsn/dque
 
 require github.com/pkg/errors v0.9.1
 
-go 1.13

--- a/go.mod
+++ b/go.mod
@@ -2,3 +2,4 @@ module github.com/joncrlsn/dque
 
 require github.com/pkg/errors v0.9.1
 
+go 1.13

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,3 @@
 module github.com/joncrlsn/dque
 
 require github.com/pkg/errors v0.9.1
-
-go 1.13

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/joncrlsn/dque
 
-require github.com/pkg/errors v0.8.0
+require github.com/pkg/errors v0.9.1
+
+go 1.13

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
 github.com/pkg/errors v0.8.0 h1:WdK/asTD0HN+q6hsWO3/vpuAkAr+tw6aNJNDFFf0+qw=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/segment.go
+++ b/segment.go
@@ -119,7 +119,7 @@ func (seg *qSegment) load() error {
 
 		// Decode the bytes into an object
 		object := seg.objectBuilder()
-		if err := dec.Decode(object); err != nil {
+		if err := gob.NewDecoder(buf).Decode(object); err != nil {
 			return errors.Wrapf(err, "failed to decode %T object from segment file %d", object, seg.number)
 		}
 

--- a/segment_test.go
+++ b/segment_test.go
@@ -6,12 +6,13 @@ package dque
 //
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
 	"testing"
+
+	"github.com/pkg/errors"
 )
 
 // item1 is the thing we'll be storing in the queue
@@ -88,7 +89,7 @@ func TestSegment(t *testing.T) {
 func TestSegment_ErrCorruptedSegment(t *testing.T) {
 	testDir := "./TestSegmentError"
 	os.RemoveAll(testDir)
-	// defer os.RemoveAll((testDir))
+	defer os.RemoveAll((testDir))
 
 	if err := os.Mkdir(testDir, 0755); err != nil {
 		t.Fatalf("Error creating directory in the TestSegment_ErrCorruptedSegment method: %s\n", err)


### PR DESCRIPTION
In order to handle automated recovery from corrupted segment files, this PR adds an explicit error type including the file path for relevant errors.