### PR TITLE
Handle additional errors when loading corrupted segments

### DIFF
--- a/segment_test.go
+++ b/segment_test.go
@@ -120,7 +120,7 @@ func TestSegment_ErrCorruptedSegment(t *testing.T) {
 	if corruptedError.Path != "TestSegmentError/0000000000000.dque" {
 		t.Fatalf("unexpected file path: %s", corruptedError.Path)
 	}
-	if corruptedError.Error() != "segment file TestSegmentError/0000000000000.dque is corrupted: error reading gob data from file: EOF" {
+	if corruptedError.Error() != "segment file TestSegmentError/0000000000000.dque is corrupted: error reading gob data from file: unexpected EOF" {
 		t.Fatalf("wrong error message: %s", corruptedError.Error())
 	}
 }


### PR DESCRIPTION
* corrupted state files containing excess deletion records (zeros) which otherwise results in a panic
* wrap gob errors

The former is surprisingly the most common form of corruption we see in production on machines that can be power cycled at will.