### PR TITLE
Run CI for all PRs, run tests with -race, only show turbo timing on errors

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,5 +1,5 @@
 name: lint
-on: push
+on: [push, pull_request]
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,5 +1,5 @@
 name: test
-on: push
+on: [push, pull_request]
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -19,7 +19,7 @@ jobs:
     - name: Build tests
       run: go test -c
     - name: Run unit tests
-      run: go test -v -cover ./...
+      run: go test -race -cover ./...
     - name: Test building on windows
       env: {GOOS: windows}
       run: go test -c

--- a/queue_test.go
+++ b/queue_test.go
@@ -316,8 +316,7 @@ func TestQueue_Turbo(t *testing.T) {
 	}
 	elapsedSafe := time.Since(start)
 
-	t.Logf("Turbo time: %v  Safe time: %v", elapsedTurbo, elapsedSafe)
-	assert(t, elapsedTurbo < elapsedSafe/2, "Turbo must be faster than safe mode")
+	assert(t, elapsedTurbo < elapsedSafe/2, "Turbo time (%v) must be faster than safe mode (%v)", elapsedTurbo, elapsedSafe)
 
 	if err := os.RemoveAll(qName); err != nil {
 		t.Fatal("Error cleaning up the queue directory:", err)


### PR DESCRIPTION
This should cause github to show CI check stats on PRs.

Removing -v from go test should get rid of the warning due to stderr output detected from t.Log