### PR TITLE
Fix concurrency issues in DequeueBlock and PeekBlock

### DIFF
--- a/queue.go
+++ b/queue.go
@@ -60,8 +60,7 @@ type DQue struct {
 
 	mutex sync.Mutex
 
-	emptyCond      *sync.Cond
-	mutexEmptyCond sync.Mutex
+	emptyCond *sync.Cond
 
 	turbo bool
 }
@@ -92,7 +91,7 @@ func New(name string, dirPath string, itemsPerSegment int, builder func() interf
 	q.fullPath = fullPath
 	q.config.ItemsPerSegment = itemsPerSegment
 	q.builder = builder
-	q.emptyCond = sync.NewCond(&q.mutexEmptyCond)
+	q.emptyCond = sync.NewCond(&q.mutex)
 
 	if err := q.lock(); err != nil {
 		return nil, err
@@ -127,7 +126,7 @@ func Open(name string, dirPath string, itemsPerSegment int, builder func() inter
 	q.fullPath = fullPath
 	q.config.ItemsPerSegment = itemsPerSegment
 	q.builder = builder
-	q.emptyCond = sync.NewCond(&q.mutexEmptyCond)
+	q.emptyCond = sync.NewCond(&q.mutex)
 
 	if err := q.lock(); err != nil {
 		return nil, err
@@ -241,6 +240,10 @@ func (q *DQue) Dequeue() (interface{}, error) {
 	q.mutex.Lock()
 	defer q.mutex.Unlock()
 
+	return q.dequeueLocked()
+}
+
+func (q *DQue) dequeueLocked() (interface{}, error) {
 	if q.fileLock == nil {
 		return nil, ErrQueueClosed
 	}
@@ -305,6 +308,10 @@ func (q *DQue) Peek() (interface{}, error) {
 	q.mutex.Lock()
 	defer q.mutex.Unlock()
 
+	return q.peekLocked()
+}
+
+func (q *DQue) peekLocked() (interface{}, error) {
 	if q.fileLock == nil {
 		return nil, ErrQueueClosed
 	}
@@ -324,10 +331,10 @@ func (q *DQue) Peek() (interface{}, error) {
 
 // DequeueBlock behaves similar to Dequeue, but is a blocking call until an item is available.
 func (q *DQue) DequeueBlock() (interface{}, error) {
-	q.mutexEmptyCond.Lock()
-	defer q.mutexEmptyCond.Unlock()
+	q.mutex.Lock()
+	defer q.mutex.Unlock()
 	for {
-		obj, err := q.Dequeue()
+		obj, err := q.dequeueLocked()
 		if err == ErrEmpty {
 			q.emptyCond.Wait()
 			// Wait() atomically unlocks mutexEmptyCond and suspends execution of the calling goroutine.
@@ -342,10 +349,10 @@ func (q *DQue) DequeueBlock() (interface{}, error) {
 
 // PeekBlock behaves similar to Peek, but is a blocking call until an item is available.
 func (q *DQue) PeekBlock() (interface{}, error) {
-	q.mutexEmptyCond.Lock()
-	defer q.mutexEmptyCond.Unlock()
+	q.mutex.Lock()
+	defer q.mutex.Unlock()
 	for {
-		obj, err := q.Peek()
+		obj, err := q.peekLocked()
 		if err == ErrEmpty {
 			q.emptyCond.Wait()
 			// Wait() atomically unlocks mutexEmptyCond and suspends execution of the calling goroutine.


### PR DESCRIPTION
The `mutexEmptyCond` mutex doesn't guard the condition that is being checked (i.e. that the queue is not empty), which makes the whole rendez-vous point ineffective.