### PR TITLE
fix file is being used by another process

### DIFF
--- a/queue.go
+++ b/queue.go
@@ -191,6 +191,10 @@ func (q *DQue) Close() error {
 	q.emptyCond.Broadcast()
 
 	// Safe-guard ourself from accidentally using segments after closing the queue
+
+	q.firstSegment.file.Close()
+	q.lastSegment.file.Close()
+
 	q.firstSegment = nil
 	q.lastSegment = nil
 


### PR DESCRIPTION
After closing the queue. The queue is not closing the file handles which were created for first or last segment which is causing issue when deleting the file after closing the queue.