### PR TITLE
Make sure the first segment is not empty or it's not complete (is current)

### DIFF
--- a/queue.go
+++ b/queue.go
@@ -520,11 +520,20 @@ func (q *DQue) load() error {
 	if maxNum > 0 {
 
 		// We found files
-		seg, err := openQueueSegment(q.fullPath, minNum, q.turbo, q.builder)
-		if err != nil {
-			return errors.Wrap(err, "unable to create queue segment in "+q.fullPath)
+		for {
+			seg, err := openQueueSegment(q.fullPath, minNum, q.turbo, q.builder)
+			if err != nil {
+				return errors.Wrap(err, "unable to create queue segment in "+q.fullPath)
+			}
+			// Make sure the first segment is not empty or it's not complete (i.e. is current)
+			if seg.size() > 0 || seg.sizeOnDisk() < q.config.ItemsPerSegment {
+				q.firstSegment = seg
+				break
+			}
+			// Try the next one
+			seg.close()
+			minNum++
 		}
-		q.firstSegment = seg
 
 		if minNum == maxNum {
 			// We have only one segment so the
@@ -532,7 +541,7 @@ func (q *DQue) load() error {
 			q.lastSegment = q.firstSegment
 		} else {
 			// We have multiple segments
-			seg, err = openQueueSegment(q.fullPath, maxNum, q.turbo, q.builder)
+			seg, err := openQueueSegment(q.fullPath, maxNum, q.turbo, q.builder)
 			if err != nil {
 				return errors.Wrap(err, "unable to create segment for "+q.fullPath)
 			}


### PR DESCRIPTION
In an edge case, on load, we found that it is possible to have the first segment being empty (size()==0) and also complete (reached q.config.ItemsPerSegment limit). 
In such queue, the Peek() and Deque() return error 'empty', but that is not correct as the queue has another segment with available objects.